### PR TITLE
Flesh out documentation and switch to using patches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ PKGNAME:=ad-ldap-connector
 PKGPATH:=https://github.com/auth0/ad-ldap-connector/archive/
 PKGSHA256:=8480a272813330fe49a0e60d17601a783ceb3660bdd195a8937160e32d400ce8
 NPMS=npm_modules.sha256sum
+RUBY_VERSION=2.7.2
 
 PKGARCHIVE:=v$(PKGVER).tar.gz
 PKGDIRNAME:=$(PKGNAME)-$(PKGVER)
@@ -34,7 +35,7 @@ fpm: extract npm_verify patch
 	mkdir -p target/usr/lib/systemd/system
 	cp -v $(PKGNAME).service target/usr/lib/systemd/system
 	cp -v environ target/opt/$(PKGNAME)/
-	~/.rvm/bin/rvm 2.7.2 do fpm -s dir -t rpm \
+	~/.rvm/bin/rvm $(RUBY_VERSION) do fpm -s dir -t rpm \
 		--rpm-user $(PKGNAME) --rpm-group $(PKGNAME) \
 		--rpm-digest sha256 \
 		--before-install pre-install.sh \
@@ -76,8 +77,8 @@ setup:
 	sudo yum install -y git unzip rpm-build nodejs gcc gcc-c++ patch autoconf automake bison libffi-devel libtool readline-devel sqlite-devel zlib-devel openssl-devel
 	gpg2 --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
 	test -e ~/.rvm/scripts/rvm || curl -sSL https://get.rvm.io | bash -s stable
-	~/.rvm/bin/rvm install 2.7.2
-	~/.rvm/bin/rvm 2.7.2 do gem install --no-document fpm
+	~/.rvm/bin/rvm install $(RUBY_VERSION)
+	~/.rvm/bin/rvm $(RUBY_VERSION) do gem install --no-document fpm
 
 .PHONY: all fpm patch clean verify download extract npm_verify npm_download regenerate_sums setup
 clean:

--- a/Makefile
+++ b/Makefile
@@ -14,11 +14,11 @@ PKGVER:= 3.9.1-mozilla
 #This is the packaging sub-release version
 PKGREL:= 1
 PKGNAME:=ad-ldap-connector
-PKGPATH:=https://github.com/mozilla-iam/ad-ldap-connector/archive/
+PKGPATH:=https://github.com/auth0/ad-ldap-connector/archive/
 PKGSHA256:=8480a272813330fe49a0e60d17601a783ceb3660bdd195a8937160e32d400ce8
 NPMS=npm_modules.sha256sum
 
-PKGTARBALL:=v$(PKGVER).tar.gz
+PKGARCHIVE:=v$(PKGVER).tar.gz
 PKGDIRNAME:=$(PKGNAME)-$(PKGVER)
 
 #Required for the fancy checksumming
@@ -27,14 +27,14 @@ SHELL:=/bin/bash
 
 all: fpm
 
-fpm: extract npm_verify
+fpm: extract npm_verify patch
 	#Creating package
 	mkdir -p target/opt
 	cp -vr $(PKGDIRNAME) target/opt/$(PKGNAME)
 	mkdir -p target/usr/lib/systemd/system
 	cp -v $(PKGNAME).service target/usr/lib/systemd/system
 	cp -v environ target/opt/$(PKGNAME)/
-	fpm -s dir -t rpm \
+	~/.rvm/bin/rvm 2.7.2 do fpm -s dir -t rpm \
 		--rpm-user $(PKGNAME) --rpm-group $(PKGNAME) \
 		--rpm-digest sha256 \
 		--before-install pre-install.sh \
@@ -43,13 +43,16 @@ fpm: extract npm_verify
 		--exclude opt/$(PKGNAME)/$(PKGNAME)-$(PKGVER) \
 		-n $(PKGNAME) -v $(PKGVER) -C target
 
+patch: $(PKGDIRNAME)
+	@cd $(PKGDIRNAME) && find ../patches -type f -name '*.patch' -print0 | sort -z | xargs -t -0 -n 1 patch --verbose -p1 -i
+
 npm_download: extract
 	@cd $(PKGDIRNAME) && npm i --production
 
 npm_verify: npm_download
 	cat $(NPMS) | sha256sum -c
 
-regenerate_sums: $(PKGARCHIVE)
+regenerate_sums: npm_download
 	@echo Generating NEW checksums...
 	find $(PKGDIRNAME)/node_modules/ -type f -exec sha256sum {} \; > npm_modules.sha256sum
 
@@ -66,7 +69,17 @@ verify: $(PKGARCHIVE)
 	@echo Verifying package checksum...
 	echo "$(PKGSHA256) $(PKGARCHIVE)" | sha256sum -c
 
-.PHONY: clean verify download extract npm_verify npm_download
+setup:
+	sudo --validate
+	sudo yum update -y
+	test -e /etc/yum.repos.d/nodesource-el7.repo || curl -sL https://rpm.nodesource.com/setup_10.x | sudo bash -
+	sudo yum install -y git unzip rpm-build nodejs gcc gcc-c++ patch autoconf automake bison libffi-devel libtool readline-devel sqlite-devel zlib-devel openssl-devel
+	gpg2 --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+	test -e ~/.rvm/scripts/rvm || curl -sSL https://get.rvm.io | bash -s stable
+	~/.rvm/bin/rvm install 2.7.2
+	~/.rvm/bin/rvm 2.7.2 do gem install --no-document fpm
+
+.PHONY: all fpm patch clean verify download extract npm_verify npm_download regenerate_sums setup
 clean:
 	-rm $(PKGARCHIVE)
 	-rm -r $(PKGDIRNAME)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-#@maintainer kang@mozilla.com
-#@update 2017-03-28
+#@maintainer gene@mozilla.com
+#@update 2020-10-23
 
 # Required RPM packaes:
 # fpm
@@ -49,26 +49,26 @@ npm_download: extract
 npm_verify: npm_download
 	cat $(NPMS) | sha256sum -c
 
-regenerate_sums: $(PKGTARBALL)
+regenerate_sums: $(PKGARCHIVE)
 	@echo Generating NEW checksums...
 	find $(PKGDIRNAME)/node_modules/ -type f -exec sha256sum {} \; > npm_modules.sha256sum
 
 extract: $(PKGDIRNAME)
 $(PKGDIRNAME): verify
-	tar xvzf $(PKGTARBALL)
+	tar xvzf $(PKGARCHIVE) || unzip $(PKGARCHIVE)
 
-download: $(PKGTARBALL)
-$(PKGTARBALL):
+download: $(PKGARCHIVE)
+$(PKGARCHIVE):
 	@echo Getting package release $(PKGVER)...
-	curl -# -L -O $(PKGPATH)$(PKGTARBALL)
+	curl -# -L -O $(PKGPATH)$(PKGARCHIVE)
 
-verify: $(PKGTARBALL)
-	@echo Verifying tarball checksum...
-	echo "$(PKGSHA256) $(PKGTARBALL)" | sha256sum -c
+verify: $(PKGARCHIVE)
+	@echo Verifying package checksum...
+	echo "$(PKGSHA256) $(PKGARCHIVE)" | sha256sum -c
 
 .PHONY: clean verify download extract npm_verify npm_download
 clean:
-	-rm $(PKGTARBALL)
+	-rm $(PKGARCHIVE)
 	-rm -r $(PKGDIRNAME)
 	-rm -r target
 	-rm *.rpm

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
-This is a wrapper for Auth0's LDAP connector.
+Packaging and customizations for Auth0's AD LDAP connector
 
 # Current state
 
-The code in this repo creates checksums and verifies that the package's checksum
-matches a known-good point in time checksum. It then packages everything into a
-single RPM and which has systemd init support added to it.
+The code in this repo
+* creates checksums
+* verifies that the package's checksum matches a known-good point in time checksum.
+* patches the Auth0 code with Mozilla specific customizations
+* packages everything into a single RPM and which has systemd init support added to it.
 
 # Ideally
 
@@ -15,35 +17,26 @@ separate RPMs.
 # Build the RPM
 
 - Provision a CentOS 7 VM to work from
-  - Update to newest : `sudo yum update`
-  - Install nodejs repo : `curl -sL https://rpm.nodesource.com/setup_10.x | sudo bash -`
-  - Install packages : `sudo yum install -y git unzip rpm-build nodejs`
-  - Install ruby :
-    ```
-    sudo yum install gcc gcc-c++ patch autoconf automake bison libffi-devel libtool readline-devel sqlite-devel zlib-devel openssl-devel
-    gpg2 --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
-    curl -sSL https://get.rvm.io | bash -s stable
-    source ~/.rvm/scripts/rvm
-    rvm install 2.7.2
-    rvm use 2.7.2 --default
-    ```
-  - Install fpm : `gem install --no-document fpm`
+  - `sudo yum install -y git`
+  - `git clone https://github.com/mozilla-iam/ad-ldap-connector-rpm && cd ad-ldap-connector-rpm`
+  - `make setup`
 - Determine if the [Mozilla fork](https://github.com/mozilla-iam/ad-ldap-connector)
   of https://github.com/auth0/ad-ldap-connector is up to date and has the version
   released that's desired. If not, merge upstream changes into the Mozilla fork
   and produce a release
-- `git clone https://github.com/mozilla-iam/ad-ldap-connector-rpm && cd ad-ldap-connector-rpm`
 - `make clean`
   - Make sure you start from a clean state, otherwise dependencies will be missing
 - Ensure that the version number you want to build is present in the `Makefile`
-- `make download`
 - `make fpm` to produce the RPM which calls in sequence
-  1. `make verify` which checks the hash of the archive
-  2. `make extract` which extracts the archive
-  3. `make npm_download` which fetches all the npm dependencies
-  4. `make npm_verify` which checks the hashes of all the dependencies
+  1. `make download` which fetches the archive
+  2. `make verify` which checks the hash of the archive
+  3. `make extract` which extracts the archive
+  4. `make npm_download` which fetches all the npm dependencies
+  5. `make npm_verify` which checks the hashes of all the dependencies
+  6. `make patch` which applies the Mozilla customizations to the `ad-ldap-connector`
 
 If you changed npm dependencies, after verifying them, you can run `make regenerate_sums`
+to produce a new `npm_modules.sha256sum` file
 
 # Install the RPM
 

--- a/README.md
+++ b/README.md
@@ -1,34 +1,80 @@
-This is a wrapper for auth0's LDAP connector.
+This is a wrapper for Auth0's LDAP connector.
 
-Current state
-============
-It checksums and verifies packages checksum match a known-good point in time checksum,
-packages everything into a single RPM and has systemd init support.
+# Current state
 
-Ideally
-=======
-The upstream package would need modifications to properly install without prompting the user on first install.
-Additionally, all npm packages should be separate RPMs.
+The code in this repo creates checksums and verifies that the package's checksum
+matches a known-good point in time checksum. It then packages everything into a
+single RPM and which has systemd init support added to it.
 
-What you have to do to use this
-===============================
+# Ideally
 
-- Make sure you start from a clean state, or else `make clean` otherwise dependencies will be missing
-- If you changed deps, after verifying them, you can run `make regenerate-sums`
-- Create ('make fpm') or download the rpm from releases
-- Install the rpm (yum or rpm -U blah.rpm)
-- Change the file /opt/ad-ldap-connector/environ if you use a proxy
-- Copy over your previous certs directory and config.json. If you have no previous version you're done.
+The upstream package would need modifications to properly install without 
+prompting the user on first install. Additionally, all npm packages should be 
+separate RPMs.
 
-To run it
-=========
-First time run requires you to run it interactively to fetch the auth0 ticket: 
-  $ sudo -u ad-ldap-connector node server.js
+# Build the RPM
+
+- Provision a CentOS 7 VM to work from
+  - Update to newest : `sudo yum update`
+  - Install nodejs repo : `curl -sL https://rpm.nodesource.com/setup_10.x | sudo bash -`
+  - Install packages : `sudo yum install -y git unzip rpm-build nodejs`
+  - Install ruby :
+    ```
+    sudo yum install gcc gcc-c++ patch autoconf automake bison libffi-devel libtool readline-devel sqlite-devel zlib-devel openssl-devel
+    gpg2 --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+    curl -sSL https://get.rvm.io | bash -s stable
+    source ~/.rvm/scripts/rvm
+    rvm install 2.7.2
+    rvm use 2.7.2 --default
+    ```
+  - Install fpm : `gem install --no-document fpm`
+- Determine if the [Mozilla fork](https://github.com/mozilla-iam/ad-ldap-connector)
+  of https://github.com/auth0/ad-ldap-connector is up to date and has the version
+  released that's desired. If not, merge upstream changes into the Mozilla fork
+  and produce a release
+- `git clone https://github.com/mozilla-iam/ad-ldap-connector-rpm && cd ad-ldap-connector-rpm`
+- `make clean`
+  - Make sure you start from a clean state, otherwise dependencies will be missing
+- Ensure that the version number you want to build is present in the `Makefile`
+- `make download`
+- `make fpm` to produce the RPM which calls in sequence
+  1. `make verify` which checks the hash of the archive
+  2. `make extract` which extracts the archive
+  3. `make npm_download` which fetches all the npm dependencies
+  4. `make npm_verify` which checks the hashes of all the dependencies
+
+If you changed npm dependencies, after verifying them, you can run `make regenerate_sums`
+
+# Install the RPM
+
+- Install the rpm (`yum` or `rpm -U ad-ldap-connector-1.2.3_mozilla-1.x86_64.rpm`)
+  - This will show the following output during installation
+    ```
+    Preparing...                          ################################# [100%]
+    id: ad-ldap-connector: no such user
+    You will need to run:
+    $ cd /opt/ad-ldap-connector && sudo -u ad-ldap-connector node server.js
+    Once manually the first time in order to setup the connector. Also ensure /opt/ad-ldap-connector/environ is set.
+    Configure /opt/ad-ldap-connector/config.json afterwards and run the usual systemd commands:
+    $ systemctl start ad-ldap-connector
+    $ systemctl enable ad-ldap-connector
+    Updating / installing...
+       1:ad-ldap-connector-1.2.3_mozilla-################################# [100%]
+    ```
+- Change the file `/opt/ad-ldap-connector/environ` if you use a proxy
+- Copy over your previous certs directory and `config.json`. If you have no 
+  previous version you're done.
+
+# Run the LDAP Connector
+
+First time run is interactive in order to fetch the Auth0 ticket:
+
+    $ sudo -u ad-ldap-connector node server.js
   
-You can then modify config.json and start the daemon:
+You can then modify `config.json` and start the daemon:
 
-  $ systemctl start ad-ldap-connector
+    $ systemctl start ad-ldap-connector
   
-  $ systemctl enable ad-ldap-connector
+    $ systemctl enable ad-ldap-connector
   
-Verify it works in https://manage.auth0.com/#/connections/enterprise
+Verify it works at https://manage.auth0.com/#/connections/enterprise

--- a/patches/001_email-verified.patch
+++ b/patches/001_email-verified.patch
@@ -1,0 +1,39 @@
+diff --git a/lib/profileMapper.js b/lib/profileMapper.js
+index 31ef24a..b503e97 100644
+--- a/lib/profileMapper.js
++++ b/lib/profileMapper.js
+@@ -1,4 +1,13 @@
+ module.exports = function (raw_data) {
++  /* Mozilla LDAP specific aliases handling */
++  var all_emails = [];
++  if (raw_data.mail) {
++    all_emails = all_emails.concat(raw_data.mail);
++  }
++  if (raw_data['zimbraAlias']) {
++    all_emails = all_emails.concat(raw_data['zimbraAlias']);
++  }
++
+   var profile = {
+     id:          raw_data.objectGUID || raw_data.uid || raw_data.cn,
+     displayName: raw_data.displayName,
+@@ -8,7 +17,7 @@ module.exports = function (raw_data) {
+     },
+     nickname: raw_data['sAMAccountName'] || raw_data['cn'] || raw_data['commonName'],
+     groups: raw_data['groups'],
+-    emails: (raw_data.mail ? [{value: raw_data.mail }] : undefined)
++    emails: all_emails
+   };
+ 
+   profile['dn'] = raw_data['dn'];
+@@ -29,7 +38,10 @@ module.exports = function (raw_data) {
+   
+   // if your LDAP service provides verified email addresses, uncomment this:
+   // profile['email_verified'] = true;
+-  
++
++  profile['email_verified'] = true; //LDAP emails are manually created through tickets, thus always verified
++  profile['email_aliases'] = (raw_data['zimbraAlias'] ? [{value: raw_data.mail }] : undefined)
++
+   // This will make the profile huge:
+   // if (raw_data['thumbnailPhoto']) {
+   //   profile['picture'] = 'data:image/bmp;base64,' +


### PR DESCRIPTION
This adds all details to go from a brand new CentOS 7 instance to a built RPM
Updates to use a patch model instead of a fork of Auth0's code

Also Update Makefile to allow for tgz or zip file
Changes to use Auth0's code and then apply a patch.
Also creates a `make setup` target which sets up the system to build the RPM

Once this PR is merged we should delete the https://github.com/mozilla-iam/ad-ldap-connector repo as it's no longer used