### PR TITLE
Add nodejs/npm dependencies to the rpm creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ fpm: extract npm_verify patch
 		--rpm-digest sha256 \
 		--before-install pre-install.sh \
 		--config-files opt/$(PKGNAME)/environ \
+		--depends nodejs --depends npm \
 		--iteration $(PKGREL) \
 		--exclude opt/$(PKGNAME)/$(PKGNAME)-$(PKGVER) \
 		-n $(PKGNAME) -v $(PKGVER) -C target


### PR DESCRIPTION
The ad-ldap-connector has a dependency upon node/npm on the server it's going to run on.  Currently we get that via puppet declaring the packages, but it'd be better to fold it into future RPM creates.