### PR TITLE
Remove proxy configuration from RPM build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,12 +36,10 @@ fpm: extract npm_verify patch
 	cp -vr $(PKGDIRNAME) target/opt/$(PKGNAME)
 	mkdir -p target/usr/lib/systemd/system
 	cp -v $(PKGNAME).service target/usr/lib/systemd/system
-	cp -v environ target/opt/$(PKGNAME)/
 	~/.rvm/bin/rvm $(RUBY_VERSION) do fpm -s dir -t rpm \
 		--rpm-user $(PKGNAME) --rpm-group $(PKGNAME) \
 		--rpm-digest sha256 \
 		--before-install pre-install.sh \
-		--config-files opt/$(PKGNAME)/environ \
 		--depends nodejs --depends npm \
 		--iteration $(PKGREL) \
 		--exclude opt/$(PKGNAME)/$(PKGNAME)-$(PKGVER)$(PKGSUFFIX) \

--- a/README.md
+++ b/README.md
@@ -40,16 +40,30 @@ to produce a new `npm_modules.sha256sum` file
   - This will show the following output during installation
     ```
     Preparing...                          ################################# [100%]
-    You will need to run:
+
+    You will need to...
+
+    * (if you have a proxy) Ensure you set up the proxy via a systemd dropin or unit file.
+
     $ cd /opt/ad-ldap-connector && sudo -u ad-ldap-connector node server.js
-    Once manually the first time in order to setup the connector. Also ensure /opt/ad-ldap-connector/environ is set.
+    once manually the first time in order to setup the connector.
+
     Configure /opt/ad-ldap-connector/config.json afterwards and run the usual systemd commands:
     $ systemctl start ad-ldap-connector
     $ systemctl enable ad-ldap-connector
+
     Updating / installing...
        1:ad-ldap-connector-1.2.3_mozilla-################################# [100%]
     ```
-- Change the file `/opt/ad-ldap-connector/environ` if you use a proxy
+- As noted, create a dropin or unit file for ad-ldap-connector.service in systemd, ala:
+  ```
+  # mkdir /etc/systemd/system/ad-ldap-connector.service.d
+  # cat << EOHEREDOC > /etc/systemd/system/ad-ldap-connector.service.d/use-proxy.conf
+  [Service]
+  Environment=http_proxy=proxy.example.com:3128
+  Environment=https_proxy=proxy.example.com:3128
+  EOHEREDOC
+  ```
 - Copy over your previous certs directory and `config.json`. If you have no 
   previous version you're done.
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ to produce a new `npm_modules.sha256sum` file
   - This will show the following output during installation
     ```
     Preparing...                          ################################# [100%]
-    id: ad-ldap-connector: no such user
     You will need to run:
     $ cd /opt/ad-ldap-connector && sudo -u ad-ldap-connector node server.js
     Once manually the first time in order to setup the connector. Also ensure /opt/ad-ldap-connector/environ is set.

--- a/ad-ldap-connector.service
+++ b/ad-ldap-connector.service
@@ -13,10 +13,6 @@ User=ad-ldap-connector
 StandardOutput=syslog
 StandardError=syslog
 SyslogIdentifier=ad-ldap-connector
-#Recent systemd only
-#PassEnvironment=http_proxy
-#Older systemd ;-)
-EnvironmentFile=/opt/ad-ldap-connector/environ
 
 [Install]
 WantedBy=multi-user.target

--- a/environ
+++ b/environ
@@ -1,2 +1,0 @@
-#http_proxy=
-#https_proxy=

--- a/pre-install.sh
+++ b/pre-install.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/bash
-id ad-ldap-connector > /dev/null || useradd ad-ldap-connector -r -d /opt/ad-ldap-connector || {
+id ad-ldap-connector >/dev/null 2>&1 || useradd ad-ldap-connector -r -d /opt/ad-ldap-connector || {
 	echo "failed to create \"ad-ldap-connector\" user"
 	exit 1
 }

--- a/pre-install.sh
+++ b/pre-install.sh
@@ -12,9 +12,15 @@ chown ad-ldap-connector:ad-ldap-connector /var/log/ad-ldap-connector.log || {
 	exit 1
 }
 
-echo "You will need to run:"
+echo ""
+echo "You will need to..."
+echo ""
+echo "* (if you have a proxy) Ensure you set up the proxy via a systemd dropin or unit file."
+echo ""
 echo "$ cd /opt/ad-ldap-connector && sudo -u ad-ldap-connector node server.js"
-echo "Once manually the first time in order to setup the connector. Also ensure /opt/ad-ldap-connector/environ is set."
+echo "once manually the first time in order to setup the connector."
+echo ""
 echo "Configure /opt/ad-ldap-connector/config.json afterwards and run the usual systemd commands:"
 echo "$ systemctl start ad-ldap-connector"
 echo "$ systemctl enable ad-ldap-connector"
+echo ""


### PR DESCRIPTION
This removes proxy management from the RPM build process.
The proxy definitions used in our build is bad:

* it is confusing in that, coming in to this repo fresh, you would expect the proxy to be handled, when actually this repo just makes a poor framework.
* it is insufficient: it doesn't actually configure the proxy, it leaves it to us to name hosts.
* it prescribes The Way to do proxy, which then requires us to adhere to it even there's better ways.

I left behind docs indicating where one should configure the proxy.  IO-2103 is open for a puppet change for us to fix the config, which is thematically linked to this PR but not tech-linked.

This is a housekeeping PR and others will follow.  No package deploy is needed after this lands.